### PR TITLE
docs: update the prop to match the underlying API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import "react-netlify-identity-widget/styles.css"
 function App() {
   const url = process.env.REACT_APP_NETLIFY_URL // supply the url of your Netlify site instance. VERY IMPORTANT
   return (
-    <IdentityContextProvider value={url}>
+    <IdentityContextProvider url={url}>
       <AuthStatusView />
     </IdentityContextProvider>
   )


### PR DESCRIPTION
The upstream provider looks for a `url` prop, so these docs were causing errors.